### PR TITLE
AGENT: Remove unreferenced variables

### DIFF
--- a/AGENT/Drivers.cpp
+++ b/AGENT/Drivers.cpp
@@ -26,16 +26,8 @@ Return Value:
 --*/
 {
     SP_DEVINSTALL_PARAMS deviceInstallParams;
-    WCHAR SectionName[LINE_LEN];
-    WCHAR DrvDescription[LINE_LEN];
-    WCHAR MfgName[LINE_LEN];
-    WCHAR ProviderName[LINE_LEN];
     HKEY hKey = NULL;
-    DWORD RegDataLength;
-    DWORD RegDataType;
-    DWORD c;
     BOOL match = FALSE;
-    long regerr;
 
     ZeroMemory(&deviceInstallParams, sizeof(deviceInstallParams));
     deviceInstallParams.cbSize = sizeof(SP_DEVINSTALL_PARAMS);


### PR DESCRIPTION
Done to fix the following warnings with Visual Studio 2022:
```
>AGENT\Drivers.cpp(29,11): warning C4101: 'SectionName': unreferenced local variable
>AGENT\Drivers.cpp(35,11): warning C4101: 'RegDataType': unreferenced local variable
>AGENT\Drivers.cpp(36,11): warning C4101: 'c': unreferenced local variable
>AGENT\Drivers.cpp(32,11): warning C4101: 'ProviderName': unreferenced local variable
>AGENT\Drivers.cpp(34,11): warning C4101: 'RegDataLength': unreferenced local variable
>AGENT\Drivers.cpp(30,11): warning C4101: 'DrvDescription': unreferenced local variable
>AGENT\Drivers.cpp(38,10): warning C4101: 'regerr': unreferenced local variable
>AGENT\Drivers.cpp(31,11): warning C4101: 'MfgName': unreferenced local variable
```