### PR TITLE
Fix ExAllocatePool deprecation warning

### DIFF
--- a/UDEFX2/Misc.c
+++ b/UDEFX2/Misc.c
@@ -148,7 +148,7 @@ WRQueuePushWrite(
         status = STATUS_SUCCESS; // til proven otherwise
 
         // allocate
-        pNewEntry = ExAllocatePool(PagedPool, sizeof(BUFFER_CONTENT) + wlen);
+        pNewEntry = ExAllocatePool2(POOL_FLAG_PAGED, sizeof(BUFFER_CONTENT) + wlen, UDEFX_POOL_TAG);
         if (pNewEntry == NULL) {
             TraceEvents(TRACE_LEVEL_ERROR,
                 TRACE_QUEUE,


### PR DESCRIPTION
Based on instructions on https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls

Fixes the following warning with Visual Studio 2022:
```
>UDEFX2\Misc.c(151,21): error C2220: the following warning is treated as an error
>UDEFX2\Misc.c(151,21): warning C4996: 'ExAllocatePool': ExAllocatePool is deprecated, use ExAllocatePool2.
```