### PR TITLE
Rename MODE enum to USB_MODE

### DIFF
--- a/AGENT/Devices.cpp
+++ b/AGENT/Devices.cpp
@@ -141,7 +141,7 @@ void PlugInUSBDevice(HANDLE controllerHandle, USHORT deviceCode, UINT64 seed, BO
     context.OnlyDesc = onlyDesc;
 
     // for simplicity modes have same values as device codes
-    context.Mode = (MODE)deviceCode;
+    context.Mode = (USB_MODE)deviceCode;
     if (!DeviceIoControl(controllerHandle,
         IOCTL_PLUG_USB_DEVICE,
         &context,                   // Ptr to InBuffer
@@ -179,7 +179,7 @@ void PlugInUSBDevice(LPGUID interfaceGuid, USHORT deviceCode) {
             context.OnlyDesc = FALSE;
 
             // for simplicity modes have same values as device codes
-            context.Mode = (MODE)deviceCode;
+            context.Mode = (USB_MODE)deviceCode;
 
             if (!DeviceIoControl(handle,
                 IOCTL_PLUG_USB_DEVICE,

--- a/UDEFX2/Fuzzing.h
+++ b/UDEFX2/Fuzzing.h
@@ -4,7 +4,7 @@
 
 // please also see Descriptor/Descriptor.h
 
-enum MODE {
+enum USB_MODE {
     NONE_MODE,          // value the same as DEFAULT_DESCRIPTOR_SET
     RESERVED_USB_30,    // value the same as KINGSTON_DESCRIPTOR_SET
     SCSI_MODE,          // value the same as FLASH_20_DESCRIPTOR_SET
@@ -18,7 +18,7 @@ typedef struct _FUZZING_CONTEXT {
     // current seed
     UINT64 Seed;
     // helpfull field to understand with protocol under USB is used now
-    MODE Mode;
+    enum USB_MODE Mode;
     // idex of descriptor set which used at start
     UINT32 DescriptorSetIndx;
     // Should fuzzing descriptor also (default false)


### PR DESCRIPTION
Suggestion for fixing #4.

Done to make the enumeration compatible with Visual Studio 2022. Also, add "enum" prefix to the `FUZZING_CONTEXT::Mode` member to make it compatible with C language builds.